### PR TITLE
Linux - add log output configuration for syslog/stdout/stderr

### DIFF
--- a/osal/os_log.h
+++ b/osal/os_log.h
@@ -24,6 +24,8 @@
 #ifndef __OS_LOG_H__
 #define __OS_LOG_H__
 
+#include <stdarg.h>
+
 typedef void (*os_log_callback)(const char*, const char*, va_list);
 
 #ifdef __cplusplus


### PR DESCRIPTION
Configure log output with "mpp_log_type" environment variable. Linux only.